### PR TITLE
Add emergency bootstrap protocol

### DIFF
--- a/dist/foreman.js
+++ b/dist/foreman.js
@@ -20,6 +20,20 @@ class Foreman {
    */
 
   /**
+   * Spawns a simple harvester if all the creeps are dead and the main spawn isn't spawning
+   * anything else.
+   */
+  emergencyBootstrap() {
+    const spawn = Game.spawns["Spawn1"]
+
+    if (!spawn.spawning && Object.values(Game.creeps).length === 0) {
+      spawn.spawnCreep([CARRY, MOVE, MOVE, WORK], this.getCreepName("harvester"), {
+        memory: { roleId: "harvester" }
+      })
+    }
+  }
+
+  /**
    * Runs cleanup at the end of the game loop.
    */
   endShift() {
@@ -47,6 +61,7 @@ class Foreman {
     this.maintainRole(BuilderRole, 3)
     this.maintainRole(UpgraderRole, 3)
     this.maintainRole(HarvesterRole, 3)
+    this.emergencyBootstrap()
   }
 
   /**


### PR DESCRIPTION
Ran into a bug where all the creeps had expired and there wasn't enough energy to spawn the best available creep body, so the normal creep role maintenance algorithms wouldn't spawn new creeps. This adds an emergency bootstrap protocol where if there are no creeps and the spawn isn't spawning anything else, to spawn a simple harvester to start things over.